### PR TITLE
FIX: The P or p was not optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tutor-point-calculator",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tutor-point-calculator",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tutor-point-calculator",
   "displayName": "Tutor Point Calculator",
   "description": "Easily calculate points of students",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "engines": {
     "vscode": "^1.83.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,7 +117,7 @@ function evaluateFile(path: string): number {
 
 	// Look lines that are like "TUTOR -xy:" using regex where XY is a whole number or a decimal number
 	let pointReduction = 0;
-	const regex = /\s*TUTOR\s*-\d+(\.\d+)?\s*[Pp]:/g;
+	const regex = /\s*TUTOR\s*-\d+(\.\d+)?\s*[Pp]?:/g;
 	for (const line of possibleGrading) {
 		line.match(regex)?.forEach((match) => {
 			// Extract the number after the "-" and add it to the point reduction


### PR DESCRIPTION
Missed the "?" after the brackets, which made the "P" or "p" required