### PR TITLE
Fix of lost comments

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,13 @@ function evaluateFile(path: string): number {
 	for (const line of fileContent) {
 		if (line.includes(commentMarker)) {
 			// Split to only get the comment and store that
-			possibleGrading.push(line.split(commentMarker)[1]);
+			const splitLine = line.split(commentMarker);
+			for (const comment of splitLine) {
+				// Check if the comment is not empty
+				if (comment.trim() !== "") {
+					possibleGrading.push(comment);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
In the case that a `// TUTOR` comment is in the same line as a normal comment, then the tutor comment was lost. This commit takes all splits from splitting by `//` and adds them for checking